### PR TITLE
Fix: a payer can't create a second stream for the payee

### DIFF
--- a/contracts/StreamManager.sol
+++ b/contracts/StreamManager.sol
@@ -49,6 +49,7 @@ contract StreamManager is IStreamManager, ReentrancyGuard {
     error AlreadyTerminatedOrTerminating();
     error AlreadyTerminated();
     error TerminatedInCliffPeriod();
+    error OpenStreamExists();
 
     struct OpenStream {
         address payee;
@@ -146,6 +147,7 @@ contract StreamManager is IStreamManager, ReentrancyGuard {
         if (_payee == address(0) || _token == address(0)) revert InvalidAddress();
         if (_rate == 0 || _terminationPeriod == 0 || _cliffPeriod == 0)
             revert InvalidValue();
+        if (streamInstances[_payee].createdAt != 0) revert OpenStreamExists();
 
         /// @dev create a new open stream instance
         streamInstances[_payee] = OpenStream(


### PR DESCRIPTION
resolves #61 